### PR TITLE
feat(docker): add Docker support for containerised deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,66 @@
+# =============================================================================
+# Docker Build Context Exclusions
+# =============================================================================
+# Exclude files that aren't needed in the build context to speed up builds
+# and reduce the amount of data sent to the Docker daemon.
+# =============================================================================
+
+# Git (keep .git for version detection during build)
+.gitignore
+.gitattributes
+
+# IDE
+.idea/
+*.iml
+.vscode/
+*.swp
+*.swo
+*~
+
+# Build outputs (we rebuild inside Docker)
+build/
+*/build/
+out/
+*.class
+
+# Gradle caches
+.gradle/
+*/.gradle/
+
+# Node modules (rebuilt inside Docker)
+nodel-webui-js/node_modules/
+
+# Local runtime data
+nodes/
+recipes/
+custom/
+cache/
+logs/
+*.lock
+.nodel/
+
+# Generated files
+_*.json
+_*.txt
+.version
+.lastHTTPPort
+
+# Documentation (not needed for build)
+*.md
+!README.md
+LICENSE*
+
+# CI/CD
+.travis.yml
+.github/
+
+# Docker files (avoid recursive context)
+docker-compose*.yml
+
+# Test data
+test-nodes/
+test-data/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,10 +9,3 @@ entrypoint.sh text eol=lf
 # Windows batch files use CRLF
 *.bat text eol=crlf
 *.cmd text eol=crlf
-
-# Keep these binary
-*.jar binary
-*.png binary
-*.jpg binary
-*.gif binary
-*.ico binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Auto-detect text files and normalise line endings
+* text=auto
+
+# Shell scripts must use LF (Unix) line endings for Docker/Linux compatibility
+*.sh text eol=lf
+gradlew text eol=lf
+entrypoint.sh text eol=lf
+
+# Windows batch files use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Keep these binary
+*.jar binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,10 @@
 #   - Version tags (v*): Builds and pushes automatically
 #   - Manual dispatch: Build any branch, optional push
 #
+# Manual builds via CLI (useful for testing branches):
+#   gh workflow run docker-publish.yml --ref <branch> --repo <owner>/nodel
+#   gh workflow run docker-publish.yml --ref <branch> --repo <owner>/nodel -f push_image=true
+#
 # Image naming: ghcr.io/<owner>/nodel:<tag>
 
 name: Docker | Build and Publish

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.ref_type == 'tag' || inputs.push_image == 'true' }}
+          push: ${{ github.ref_type == 'tag' || inputs.push_image }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,151 @@
+# Publishes Docker images to GitHub Container Registry (GHCR)
+# Triggers: version tags (v*) or manual dispatch (build-only by default)
+#
+# Image naming: ghcr.io/<owner>/nodel:<tag>
+# Works on both fork (scroix/nodel) and upstream (museumsvictoria/nodel)
+
+name: Docker | Build and Publish
+
+on:
+  push:
+    branches:
+      - feature/docker-support
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to registry'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version metadata
+        id: version
+        run: |
+          REV_COUNT=$(git rev-list --count HEAD)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BASE_VERSION=$(grep "baseVersion = " build.gradle | sed "s/.*baseVersion = '\([^']*\)'.*/\1/")
+
+          # Validate all extracted values
+          if [[ -z "$BASE_VERSION" ]]; then
+            echo "::error::Failed to extract baseVersion from build.gradle"
+            exit 1
+          fi
+          # Validate version format for Docker tag compatibility
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "::error::Invalid version format: '$BASE_VERSION' (expected semver-like pattern)"
+            exit 1
+          fi
+          if [[ -z "$REV_COUNT" || ! "$REV_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "::error::Failed to get valid commit count (got: '$REV_COUNT')"
+            exit 1
+          fi
+          if [[ -z "$SHORT_SHA" ]]; then
+            echo "::error::Failed to get short SHA"
+            exit 1
+          fi
+
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"
+          else
+            BRANCH="${{ github.ref_name }}"
+            BRANCH="${BRANCH//\//-}"
+            VERSION="${BASE_VERSION}-${BRANCH}.r${REV_COUNT}"
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "revision=${REV_COUNT}" >> $GITHUB_OUTPUT
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "base_version=${BASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref, '-') }}
+            type=ref,event=branch
+            type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=Nodel
+            org.opencontainers.image.description=Digital media control system for museums, galleries, and corporate environments
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.vendor=Museums Victoria
+            org.opencontainers.image.licenses=MPL-2.0
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.build_date }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'workflow_dispatch' || inputs.push_image == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            BUILD_DATE=${{ steps.version.outputs.build_date }}
+            GIT_COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate build summary
+        run: |
+          echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          PUSH_ENABLED="${{ github.event_name != 'workflow_dispatch' || inputs.push_image == 'true' }}"
+          if [ "$PUSH_ENABLED" == "true" ]; then
+            echo "✅ **Status:** Image pushed to registry" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⏸️ **Status:** Image built but NOT pushed (manual dispatch with push_image=false)" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,15 +1,15 @@
 # Publishes Docker images to GitHub Container Registry (GHCR)
-# Triggers: version tags (v*) or manual dispatch (build-only by default)
+#
+# Triggers:
+#   - Version tags (v*): Builds and pushes automatically
+#   - Manual dispatch: Build any branch, optional push
 #
 # Image naming: ghcr.io/<owner>/nodel:<tag>
-# Works on both fork (scroix/nodel) and upstream (museumsvictoria/nodel)
 
 name: Docker | Build and Publish
 
 on:
   push:
-    branches:
-      - feature/docker-support
     tags:
       - 'v*'
   workflow_dispatch:
@@ -120,7 +120,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'workflow_dispatch' || inputs.push_image == 'true' }}
+          push: ${{ github.ref_type == 'tag' || inputs.push_image == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -134,11 +134,10 @@ jobs:
         run: |
           echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          PUSH_ENABLED="${{ github.event_name != 'workflow_dispatch' || inputs.push_image == 'true' }}"
-          if [ "$PUSH_ENABLED" == "true" ]; then
+          if [[ "${{ github.ref_type }}" == "tag" || "${{ inputs.push_image }}" == "true" ]]; then
             echo "✅ **Status:** Image pushed to registry" >> $GITHUB_STEP_SUMMARY
           else
-            echo "⏸️ **Status:** Image built but NOT pushed (manual dispatch with push_image=false)" >> $GITHUB_STEP_SUMMARY
+            echo "⏸️ **Status:** Image built but NOT pushed" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@
 .lastHTTPPort
 _instance.lock
 _lastError.txt
+/nodes/
+/custom/
+/logs/
+/cache/
+/docker-compose.override.yml
+/recipes/nodel-official-recipes/
 /nodel-webui-js/.classpath
 /nodel-webui-js/.project
 /nodel-webui-js/.settings

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -10,7 +10,14 @@ Run Nodel with a single command:
 
 Web UI available at http://localhost:8085
 
-The installer pulls the latest Nodel image and runs it in a self-contained container. Node configurations are stored inside the container.
+Override defaults with environment variables:
+
+```bash
+PORT=8086 NAME=nodel2 IMAGE=ghcr.io/museumsvictoria/nodel:2.3.0 \
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
+```
+
+The installer pulls the image and runs it in a self-contained container. Node configurations are stored inside the container.
 
 ## Manual Docker Run
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -121,6 +121,7 @@ The image includes a built-in health check that polls `/REST/` every 30 seconds.
 Notes
 =====
 
+* Trigger an image build manually: `gh workflow run docker-publish.yml --ref <branch> -f push_image=true`
 * Images are available for both `amd64` and `arm64` architectures
 * For service/daemon setup on the host, see the [wiki pages](https://github.com/museumsvictoria/nodel/wiki)
 * Drop [recipes](https://github.com/museumsvictoria/nodel-recipes) into the nodes folder to get started

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -99,8 +99,6 @@ docker run -d --name nodel -p 8085:8085 \
   ghcr.io/museumsvictoria/nodel
 ```
 
-> **Tip:** Use `--user 0 -e NODEL_FIX_PERMS=1` if mounted directories have permission issues.
-
 Configuration
 =============
 
@@ -124,6 +122,5 @@ Notes
 =====
 
 * Images are available for both `amd64` and `arm64` architectures
-* The container runs as a non-root user by default for security
 * For service/daemon setup on the host, see the [wiki pages](https://github.com/museumsvictoria/nodel/wiki)
 * Drop [recipes](https://github.com/museumsvictoria/nodel-recipes) into the nodes folder to get started

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -150,10 +150,6 @@ To set a custom hostname:
 docker run -d --name nodel --hostname my-nodel-host -p 8085:8085 \
   ghcr.io/museumsvictoria/nodel
 
-# Or via environment variable
-docker run -d --name nodel -e HOSTNAME=my-nodel-host -p 8085:8085 \
-  ghcr.io/museumsvictoria/nodel
-
 # Or via JVM system property
 docker run -d --name nodel -p 8085:8085 \
   -e JAVA_OPTS="-Dnodel.hostname=my-nodel-host" \

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,27 +1,45 @@
-# Running Nodel with Docker
+<div align="center">
 
-## Quick Start
+  <img src="http://nodel.io/media/1066/logo-nodel.png" alt="Nodel logo" height="110">
 
-Run Nodel with a single command:
+  <h3>Nodel, on Docker.</h3>
+
+  <p>
+    <a href="https://github.com/museumsvictoria/nodel/pkgs/container/nodel">
+      <img src="https://img.shields.io/badge/registry-ghcr.io-blue" alt="Container Registry">
+    </a>
+  </p>
+
+</div>
+
+##### Run Nodel anywhere Docker runs.
+
+The official container image packages everything needed to get started in seconds.
+
+###### Why Docker?
+
+* No Java installation required on the host
+* Consistent environment across all deployments
+* Easy updates with a single pull command
+* Isolated from host system dependencies
+
+-------------
+
+Quick Start
+===========
+
+The fastest way to get Nodel running is with the install script:
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
 ```
 
-Web UI available at http://localhost:8085
+This creates a persistent container named `nodel` on port 8085. Once running, open http://localhost:8085 in your browser.
 
-Override defaults with environment variables:
+> **Tip:** Customise with `PORT`, `NAME`, or `IMAGE` env vars before the command.
 
-```bash
-PORT=8086 NAME=nodel2 IMAGE=ghcr.io/museumsvictoria/nodel:2.3.0 \
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
-```
-
-The installer pulls the image and runs it in a self-contained container. Node configurations are stored inside the container.
-
-## Manual Docker Run
-
-For more control, run Docker commands directly.
+Running Nodel
+=============
 
 Pull the image:
 
@@ -29,136 +47,66 @@ Pull the image:
 docker pull ghcr.io/museumsvictoria/nodel:latest
 ```
 
-For interactive testing (press Enter to shutdown):
+Interactive (Ctrl+C to stop):
 
 ```bash
 docker run --rm -it -p 8085:8085 ghcr.io/museumsvictoria/nodel
 ```
 
-For background/daemon mode:
+Detached with auto-restart:
 
 ```bash
 docker run -d --name nodel -p 8085:8085 --restart unless-stopped \
   ghcr.io/museumsvictoria/nodel
 ```
 
-Pass Nodel arguments directly after the image name:
+Pass Nodel arguments after the image name:
 
 ```bash
 docker run --rm -it -p 8086:8086 ghcr.io/museumsvictoria/nodel -p 8086
 ```
 
-## Persistent Data
+Development
+===========
 
-To persist node configurations on the host filesystem, add volume mounts:
+Build and run using Docker Compose:
 
 ```bash
-docker run -d --name nodel -p 8085:8085 --restart unless-stopped \
+docker compose up --build -d
+```
+
+> **Tip:** Use a `docker-compose.override.yml` to swap in a local image or tweak settings without modifying the base file.
+
+Data Persistence
+================
+
+Node configurations are stored inside the container by default. Named containers retain data across restarts, but it's lost if the container is removed (`docker rm`). Mount host directories as volumes to keep data independent of the container lifecycle.
+
+Mount your nodes folder:
+
+```bash
+docker run -d --name nodel -p 8085:8085 \
+  -v ./nodes:/app/nodes \
+  ghcr.io/museumsvictoria/nodel
+```
+
+Or mount multiple directories:
+
+```bash
+docker run -d --name nodel -p 8085:8085 \
   -v ./nodes:/app/nodes \
   -v ./recipes:/app/recipes \
-  -v ./custom:/app/custom \
   ghcr.io/museumsvictoria/nodel
 ```
 
-This mimics the traditional `java -jar nodel.jar` behaviour where directories appear in your working folder.
+> **Tip:** Use `--user 0 -e NODEL_FIX_PERMS=1` if mounted directories have permission issues.
 
-## Configuration
+Configuration
+=============
 
-Nodel uses `bootstrap.json` for configuration. Mount your config file:
+### JVM options
 
-```bash
-docker run -d --name nodel -p 8085:8085 \
-  -v ./bootstrap.json:/app/bootstrap.json \
-  -v ./nodes:/app/nodes \
-  ghcr.io/museumsvictoria/nodel
-```
-
-### Example bootstrap.json
-
-```json
-{
-  "NodelHostPort": 8085,
-  "disableAdvertisements": false,
-  "nodelRoot": "nodes",
-  "recipesRoot": "recipes",
-  "logsDirectory": "logs",
-  "cacheDirectory": "cache"
-}
-```
-
-### Configuration Options
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `NodelHostPort` | 8085 | HTTP port for web UI and REST API |
-| `disableAdvertisements` | false | Disable multicast discovery |
-| `nodelRoot` | nodes | Directory containing node scripts |
-| `recipesRoot` | recipes | Directory containing recipe templates |
-| `logsDirectory` | logs | Directory for log files |
-| `cacheDirectory` | cache | Directory for cache files |
-| `networkInterfaces` | (all) | Specific network interfaces to bind |
-| `inclFilters` | (none) | Only host nodes matching patterns |
-| `exclFilters` | (none) | Exclude nodes matching patterns |
-
-Run `docker run --rm ghcr.io/museumsvictoria/nodel --help` for full options.
-
-## Volumes
-
-| Path | Purpose |
-|------|---------|
-| `/app/nodes` | Node scripts and configurations |
-| `/app/recipes` | Recipe templates |
-| `/app/custom` | User customizations |
-| `/app/logs` | Log files (optional) |
-| `/app/cache` | Cache files (optional) |
-| `/app/bootstrap.json` | Configuration file (optional) |
-
-## Permissions
-
-The container runs as a non-root `nodel` user by default (UID/GID 1000). If you bind-mount host folders with incompatible ownership/permissions, either adjust the host permissions or run the container as root and enable permission fixing:
-
-```bash
-docker run -d --name nodel -p 8085:8085 --user 0 -e NODEL_FIX_PERMS=1 \
-  -v ./nodes:/app/nodes \
-  ghcr.io/museumsvictoria/nodel
-```
-
-## Network Mode
-
-Nodel uses multicast discovery (224.0.0.252:5354) for node discovery.
-
-- Docker Desktop (macOS/Windows): does not provide true `--network host`, so discovery across the host LAN is typically unavailable. Use bridge mode with port mappings (the default).
-- Linux: you can use host networking for discovery on the host LAN:
-
-```bash
-docker run -d --name nodel --network host ghcr.io/museumsvictoria/nodel
-```
-
-## Hostname Configuration
-
-Nodel reports its hostname in the web UI and discovery protocol. In Docker, the hostname is determined in this order:
-
-1. DNS-resolvable hostname (normal operation)
-2. `-Dnodel.hostname=` system property
-3. `HOSTNAME` environment variable (Docker sets this automatically)
-4. Container ID (fallback)
-
-To set a custom hostname:
-
-```bash
-# Using Docker's --hostname flag
-docker run -d --name nodel --hostname my-nodel-host -p 8085:8085 \
-  ghcr.io/museumsvictoria/nodel
-
-# Or via JVM system property
-docker run -d --name nodel -p 8085:8085 \
-  -e JAVA_OPTS="-Dnodel.hostname=my-nodel-host" \
-  ghcr.io/museumsvictoria/nodel
-```
-
-## JVM Tuning
-
-Adjust JVM settings via the `JAVA_OPTS` environment variable:
+Tune Java memory settings with the `JAVA_OPTS` environment variable:
 
 ```bash
 docker run -d --name nodel -p 8085:8085 \
@@ -166,18 +114,16 @@ docker run -d --name nodel -p 8085:8085 \
   ghcr.io/museumsvictoria/nodel
 ```
 
-Default: `-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0`
+Default JVM options: `-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0`
 
-## Health Check
+### Health check
 
-The container includes a health check that polls the REST API every 30 seconds. It automatically detects the port from Nodel's `.lastHTTPPort` file, so it works regardless of your bootstrap.json configuration.
+The image includes a built-in health check that polls `/REST/` every 30 seconds. It automatically detects the HTTP port from `.lastHTTPPort` if present.
 
-## Development
+Notes
+=====
 
-For local development and building from source, use `docker-compose.yml`:
-
-```bash
-docker compose up --build -d
-```
-
-This builds from the local source and runs Nodel in self-contained mode.
+* Images are available for both `amd64` and `arm64` architectures
+* The container runs as a non-root user by default for security
+* For service/daemon setup on the host, see the [wiki pages](https://github.com/museumsvictoria/nodel/wiki)
+* Drop [recipes](https://github.com/museumsvictoria/nodel-recipes) into the nodes folder to get started

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,180 @@
+# Running Nodel with Docker
+
+## Quick Start
+
+Run Nodel with a single command:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
+```
+
+Web UI available at http://localhost:8085
+
+The installer pulls the latest Nodel image and runs it in a self-contained container. Node configurations are stored inside the container.
+
+## Manual Docker Run
+
+For more control, run Docker commands directly.
+
+Pull the image:
+
+```bash
+docker pull ghcr.io/museumsvictoria/nodel:latest
+```
+
+For interactive testing (press Enter to shutdown):
+
+```bash
+docker run --rm -it -p 8085:8085 ghcr.io/museumsvictoria/nodel
+```
+
+For background/daemon mode:
+
+```bash
+docker run -d --name nodel -p 8085:8085 --restart unless-stopped \
+  ghcr.io/museumsvictoria/nodel
+```
+
+Pass Nodel arguments directly after the image name:
+
+```bash
+docker run --rm -it -p 8086:8086 ghcr.io/museumsvictoria/nodel -p 8086
+```
+
+## Persistent Data
+
+To persist node configurations on the host filesystem, add volume mounts:
+
+```bash
+docker run -d --name nodel -p 8085:8085 --restart unless-stopped \
+  -v ./nodes:/app/nodes \
+  -v ./recipes:/app/recipes \
+  -v ./custom:/app/custom \
+  ghcr.io/museumsvictoria/nodel
+```
+
+This mimics the traditional `java -jar nodel.jar` behaviour where directories appear in your working folder.
+
+## Configuration
+
+Nodel uses `bootstrap.json` for configuration. Mount your config file:
+
+```bash
+docker run -d --name nodel -p 8085:8085 \
+  -v ./bootstrap.json:/app/bootstrap.json \
+  -v ./nodes:/app/nodes \
+  ghcr.io/museumsvictoria/nodel
+```
+
+### Example bootstrap.json
+
+```json
+{
+  "NodelHostPort": 8085,
+  "disableAdvertisements": false,
+  "nodelRoot": "nodes",
+  "recipesRoot": "recipes",
+  "logsDirectory": "logs",
+  "cacheDirectory": "cache"
+}
+```
+
+### Configuration Options
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `NodelHostPort` | 8085 | HTTP port for web UI and REST API |
+| `disableAdvertisements` | false | Disable multicast discovery |
+| `nodelRoot` | nodes | Directory containing node scripts |
+| `recipesRoot` | recipes | Directory containing recipe templates |
+| `logsDirectory` | logs | Directory for log files |
+| `cacheDirectory` | cache | Directory for cache files |
+| `networkInterfaces` | (all) | Specific network interfaces to bind |
+| `inclFilters` | (none) | Only host nodes matching patterns |
+| `exclFilters` | (none) | Exclude nodes matching patterns |
+
+Run `docker run --rm ghcr.io/museumsvictoria/nodel --help` for full options.
+
+## Volumes
+
+| Path | Purpose |
+|------|---------|
+| `/app/nodes` | Node scripts and configurations |
+| `/app/recipes` | Recipe templates |
+| `/app/custom` | User customizations |
+| `/app/logs` | Log files (optional) |
+| `/app/cache` | Cache files (optional) |
+| `/app/bootstrap.json` | Configuration file (optional) |
+
+## Permissions
+
+The container runs as a non-root `nodel` user by default (UID/GID 1000). If you bind-mount host folders with incompatible ownership/permissions, either adjust the host permissions or run the container as root and enable permission fixing:
+
+```bash
+docker run -d --name nodel -p 8085:8085 --user 0 -e NODEL_FIX_PERMS=1 \
+  -v ./nodes:/app/nodes \
+  ghcr.io/museumsvictoria/nodel
+```
+
+## Network Mode
+
+Nodel uses multicast discovery (224.0.0.252:5354) for node discovery.
+
+- Docker Desktop (macOS/Windows): does not provide true `--network host`, so discovery across the host LAN is typically unavailable. Use bridge mode with port mappings (the default).
+- Linux: you can use host networking for discovery on the host LAN:
+
+```bash
+docker run -d --name nodel --network host ghcr.io/museumsvictoria/nodel
+```
+
+## Hostname Configuration
+
+Nodel reports its hostname in the web UI and discovery protocol. In Docker, the hostname is determined in this order:
+
+1. DNS-resolvable hostname (normal operation)
+2. `-Dnodel.hostname=` system property
+3. `HOSTNAME` environment variable (Docker sets this automatically)
+4. Container ID (fallback)
+
+To set a custom hostname:
+
+```bash
+# Using Docker's --hostname flag
+docker run -d --name nodel --hostname my-nodel-host -p 8085:8085 \
+  ghcr.io/museumsvictoria/nodel
+
+# Or via environment variable
+docker run -d --name nodel -e HOSTNAME=my-nodel-host -p 8085:8085 \
+  ghcr.io/museumsvictoria/nodel
+
+# Or via JVM system property
+docker run -d --name nodel -p 8085:8085 \
+  -e JAVA_OPTS="-Dnodel.hostname=my-nodel-host" \
+  ghcr.io/museumsvictoria/nodel
+```
+
+## JVM Tuning
+
+Adjust JVM settings via the `JAVA_OPTS` environment variable:
+
+```bash
+docker run -d --name nodel -p 8085:8085 \
+  -e JAVA_OPTS="-XX:MaxRAMPercentage=50.0 -Xms256m" \
+  ghcr.io/museumsvictoria/nodel
+```
+
+Default: `-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0`
+
+## Health Check
+
+The container includes a health check that polls the REST API every 30 seconds. It automatically detects the port from Nodel's `.lastHTTPPort` file, so it works regardless of your bootstrap.json configuration.
+
+## Development
+
+For local development and building from source, use `docker-compose.yml`:
+
+```bash
+docker compose up --build -d
+```
+
+This builds from the local source and runs Nodel in self-contained mode.

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,5 +84,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 # Entrypoint handles optional permission fixing on mounted volumes.
 # Configuration: mount bootstrap.json to /app/bootstrap.json (see DOCKER.md)
-USER nodel
+# Note: Container starts as root; entrypoint drops to 'nodel' user via su-exec.
 ENTRYPOINT ["/sbin/tini","--","/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,18 +48,12 @@ LABEL org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${GIT_COMMIT}"
 
-# Install tini for proper signal handling and su-exec for privilege dropping.
-RUN apk add --no-cache tini su-exec
-
-# Create non-root user for security (UID/GID 1000 for compatibility with host volume mounts)
-RUN addgroup -g 1000 nodel && adduser -u 1000 -G nodel -h /app -D nodel
+# Install tini for proper signal handling.
+RUN apk add --no-cache tini
 
 WORKDIR /app
 COPY --from=builder /build/nodelhost.jar .
 COPY --chmod=755 entrypoint.sh /entrypoint.sh
-
-RUN mkdir -p nodes recipes custom logs cache .nodel && \
-    chown -R nodel:nodel /app
 
 # JVM tuning: UseContainerSupport (default since Java 10) enables container-aware memory limits;
 # RAM percentages cap heap relative to container memory to reduce OOM risk
@@ -71,7 +65,4 @@ EXPOSE 8085
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD wget -q --spider http://localhost:$(cat /app/.lastHTTPPort 2>/dev/null || echo 8085)/REST/
 
-# Entrypoint handles optional permission fixing on mounted volumes.
-# Configuration: mount bootstrap.json to /app/bootstrap.json (see DOCKER.md)
-# Note: Container starts as root; entrypoint drops to 'nodel' user via su-exec.
-ENTRYPOINT ["/sbin/tini","--","/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1
+# Build stage
+FROM eclipse-temurin:21-jdk AS builder
+
+# Optional: CI can pass these build args to override git-detected values.
+# Empty defaults let git detection work when args aren't provided.
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+ARG GIT_REV
+ARG GIT_ORIGIN
+ENV NODEL_BUILD_ID="${GIT_COMMIT}" \
+    NODEL_BUILD_BRANCH="${GIT_BRANCH}" \
+    NODEL_BUILD_REV="${GIT_REV}" \
+    NODEL_BUILD_ORIGIN="${GIT_ORIGIN}"
+
+# Git enables build metadata (branch, revision) from the checked-out repo.
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Prefer cached dependency downloads by copying build descriptors first.
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle/ ./gradle/
+COPY nodel-framework/build.gradle nodel-framework/build.gradle
+COPY nodel-jyhost/build.gradle nodel-jyhost/build.gradle
+COPY nodel-webui-js/build.gradle nodel-webui-js/build.gradle
+COPY nodel-webui-js/package.json nodel-webui-js/package.json
+COPY nodel-webui-js/package-lock.json nodel-webui-js/package-lock.json
+COPY nodel-webui-js/Gruntfile.js nodel-webui-js/Gruntfile.js
+
+RUN --mount=type=cache,target=/root/.gradle \
+    chmod +x gradlew \
+    && ./gradlew :nodel-jyhost:dependencies --no-daemon
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :nodel-jyhost:unversioned --no-daemon \
+    && test -s nodel-jyhost/build/distributions/standalone/nodelhost.jar \
+    && cp nodel-jyhost/build/distributions/standalone/nodelhost.jar /build/nodelhost.jar
+
+# Runtime stage
+FROM eclipse-temurin:21-jre-alpine
+
+# Static labels
+LABEL org.opencontainers.image.title="Nodel" \
+      org.opencontainers.image.description="Digital media control system for museums, galleries, and corporate environments" \
+      org.opencontainers.image.url="https://github.com/museumsvictoria/nodel" \
+      org.opencontainers.image.source="https://github.com/museumsvictoria/nodel" \
+      org.opencontainers.image.vendor="Museums Victoria" \
+      org.opencontainers.image.licenses="MPL-2.0"
+
+# Dynamic labels (optional build args)
+ARG VERSION
+ARG BUILD_DATE
+ARG GIT_COMMIT
+
+LABEL org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${GIT_COMMIT}"
+
+# Install tini for proper signal handling and su-exec for privilege dropping.
+RUN apk add --no-cache tini su-exec
+
+# Create non-root user for security (UID/GID 1000 for compatibility with host volume mounts)
+RUN addgroup -g 1000 nodel && adduser -u 1000 -G nodel -h /app -D nodel
+
+WORKDIR /app
+COPY --from=builder /build/nodelhost.jar .
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+
+RUN mkdir -p nodes recipes custom logs cache .nodel && \
+    chown -R nodel:nodel /app
+
+# JVM tuning: UseContainerSupport (default since Java 10) enables container-aware memory limits;
+# RAM percentages cap heap relative to container memory to reduce OOM risk
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
+
+# Default port (configurable via bootstrap.json NodelHostPort setting)
+EXPOSE 8085
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD wget -q --spider http://localhost:$(cat /app/.lastHTTPPort 2>/dev/null || echo 8085)/REST/
+
+# Entrypoint handles optional permission fixing on mounted volumes.
+# Configuration: mount bootstrap.json to /app/bootstrap.json (see DOCKER.md)
+USER nodel
+ENTRYPOINT ["/sbin/tini","--","/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,6 @@
 # Build stage
 FROM eclipse-temurin:21-jdk AS builder
 
-# Optional: CI can pass these build args to override git-detected values.
-# Empty defaults let git detection work when args aren't provided.
-ARG GIT_COMMIT
-ARG GIT_BRANCH
-ARG GIT_REV
-ARG GIT_ORIGIN
-ENV NODEL_BUILD_ID="${GIT_COMMIT}" \
-    NODEL_BUILD_BRANCH="${GIT_BRANCH}" \
-    NODEL_BUILD_REV="${GIT_REV}" \
-    NODEL_BUILD_ORIGIN="${GIT_ORIGIN}"
-
 # Git enables build metadata (branch, revision) from the checked-out repo.
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# Development compose file - for building and testing locally
+# For production deployments, use install.sh instead
+services:
+  nodel:
+    build: .
+    image: nodel:local
+    ports:
+      - "8085:8085"
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+# Optional: fix ownership of mounted volumes (can be slow on large trees).
+# Enable with NODEL_FIX_PERMS=1 (runs as root before dropping privileges).
+if [ "${NODEL_FIX_PERMS:-}" = "1" ] && [ "$(id -u)" = "0" ]; then
+  for dir in /app/nodes /app/recipes /app/logs /app/cache /app/custom; do
+    if [ -d "$dir" ]; then
+      chown -R nodel:nodel "$dir" 2>/dev/null || true
+    fi
+  done
+fi
+
+# Verify JAR exists
+if [ ! -f /app/nodelhost.jar ]; then
+  echo "ERROR: nodelhost.jar not found" >&2
+  exit 1
+fi
+
+# Drop privileges and run Nodel
+# Configuration: mount bootstrap.json to /app/bootstrap.json (see DOCKER.md)
+# "$@" passes any args to Nodel (e.g., `docker run nodel -p 8086`)
+# tail -f /dev/null keeps stdin open (Nodel reads stdin; EOF triggers graceful exit)
+if [ "$(id -u)" = "0" ]; then
+  exec tail -f /dev/null | su-exec nodel java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@"
+else
+  exec tail -f /dev/null | java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,28 +1,10 @@
 #!/bin/sh
 set -e
 
-# Optional: fix ownership of mounted volumes (can be slow on large trees).
-# Enable with NODEL_FIX_PERMS=1 (runs as root before dropping privileges).
-if [ "${NODEL_FIX_PERMS:-}" = "1" ] && [ "$(id -u)" = "0" ]; then
-  for dir in /app/nodes /app/recipes /app/logs /app/cache /app/custom; do
-    if [ -d "$dir" ]; then
-      chown -R nodel:nodel "$dir" 2>/dev/null || true
-    fi
-  done
-fi
-
-# Verify JAR exists
 if [ ! -f /app/nodelhost.jar ]; then
   echo "ERROR: nodelhost.jar not found" >&2
   exit 1
 fi
 
-# Drop privileges and run Nodel
-# Configuration: mount bootstrap.json to /app/bootstrap.json (see DOCKER.md)
-# "$@" passes any args to Nodel (e.g., `docker run nodel -p 8086`)
 # tail -f /dev/null keeps stdin open (Nodel reads stdin; EOF triggers graceful exit)
-if [ "$(id -u)" = "0" ]; then
-  exec tail -f /dev/null | su-exec nodel java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@"
-else
-  exec tail -f /dev/null | java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@"
-fi
+exec tail -f /dev/null | java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Nodel Docker Installer
+#
+# Usage:
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
+#
+set -e
+
+# Defaults
+PORT=8085
+NAME="nodel"
+IMAGE="ghcr.io/museumsvictoria/nodel:latest"
+
+# Colours (if terminal supports them)
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'
+  NC='\033[0m' # No Colour
+else
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  NC=''
+fi
+
+log() {
+  echo -e "${BLUE}[nodel]${NC} $1"
+}
+
+error() {
+  echo -e "${RED}[error]${NC} $1" >&2
+}
+
+success() {
+  echo -e "${GREEN}[success]${NC} $1"
+}
+
+warn() {
+  echo -e "${YELLOW}[warn]${NC} $1"
+}
+
+# Check Docker is installed
+if ! command -v docker &> /dev/null; then
+  error "Docker is not installed"
+  echo ""
+  echo "Please install Docker first:"
+  echo "  https://docs.docker.com/get-docker/"
+  exit 1
+fi
+
+# Check Docker daemon is running
+if ! docker info &> /dev/null; then
+  error "Docker daemon is not running"
+  echo ""
+  echo "Please start Docker and try again"
+  exit 1
+fi
+
+# Check if container already exists
+if docker container inspect "$NAME" &> /dev/null; then
+  warn "Container '$NAME' already exists"
+  echo ""
+  echo "To reinstall, first remove the existing container:"
+  echo "  docker rm -f $NAME"
+  exit 1
+fi
+
+# Check if port is in use by another container
+if docker ps --format '{{.Ports}}' | grep -q ":$PORT->"; then
+  warn "Port $PORT appears to be in use by another container"
+  exit 1
+fi
+
+log "Pulling Nodel image..."
+docker pull "$IMAGE"
+
+log "Starting Nodel..."
+docker run -d \
+  --name "$NAME" \
+  --restart unless-stopped \
+  -p "$PORT:$PORT" \
+  "$IMAGE" -p "$PORT" > /dev/null
+
+echo ""
+success "Nodel is running!"
+echo ""
+echo "  Web UI:    http://localhost:$PORT"
+echo ""
+echo "Commands:"
+echo "  docker logs $NAME       # View logs"
+echo "  docker stop $NAME       # Stop Nodel"
+echo "  docker start $NAME      # Start Nodel"
+echo "  docker rm -f $NAME      # Remove container"

--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,16 @@
 # Usage:
 #   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
 #
+# With options:
+#   PORT=8086 NAME=nodel2 IMAGE=ghcr.io/scroix/nodel:latest \
+#     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
+#
 set -e
 
-# Defaults
-PORT=8085
-NAME="nodel"
-IMAGE="ghcr.io/museumsvictoria/nodel:latest"
+# Defaults (override with environment variables)
+PORT=${PORT:-8085}
+NAME=${NAME:-"nodel"}
+IMAGE=${IMAGE:-"ghcr.io/museumsvictoria/nodel:latest"}
 
 # Colours (if terminal supports them)
 if [ -t 1 ]; then

--- a/nodel-framework/src/main/java/org/nodel/discovery/TopologyWatcher.java
+++ b/nodel-framework/src/main/java/org/nodel/discovery/TopologyWatcher.java
@@ -373,11 +373,26 @@ public class TopologyWatcher {
                     // skip this interface
                 }
             }
-            
-            hostname = InetAddress.getLocalHost().getHostName();
-            
+
         } catch (Exception exc) {
-            _logger.warn("TopologyWatcher: Was not able to enumerate network interfaces or get hostname", exc);
+            _logger.warn("TopologyWatcher: Was not able to enumerate network interfaces", exc);
+        }
+
+        // Separate hostname lookup - can fail independently (e.g., in Docker containers)
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (Exception exc) {
+            // Fallback: try system property or environment variable
+            hostname = System.getProperty("nodel.hostname");
+            if (hostname == null || hostname.isEmpty()) {
+                hostname = System.getenv("HOSTNAME");
+            }
+            if (hostname == null || hostname.isEmpty()) {
+                hostname = "UNKNOWN";
+                _logger.debug("TopologyWatcher: Could not resolve hostname, using UNKNOWN", exc);
+            } else {
+                _logger.debug("TopologyWatcher: Using hostname from environment: {}", hostname);
+            }
         }
 
         if (optInList.length > 0 && !foundAnyMatch) {

--- a/nodel-webui-js/build.gradle
+++ b/nodel-webui-js/build.gradle
@@ -48,6 +48,7 @@ npmInstall.args = ['--legacy-peer-deps']
 
 class FileChecker {
     def nodeModulesDir
+    def gruntOutputDir
     def srcDir
     def packageJson
     def packageLockJson
@@ -55,6 +56,7 @@ class FileChecker {
 
     FileChecker(Project project) {
         nodeModulesDir = project.file("${project.projectDir}/node_modules")
+        gruntOutputDir = project.file("${project.buildDir}/grunt")
         srcDir = project.file('src')
         packageJson = project.file('package.json')
         packageLockJson = project.file('package-lock.json')
@@ -62,18 +64,23 @@ class FileChecker {
     }
 
     def checkFilesChanged() {
+        // Always rebuild if grunt output doesn't exist or is empty
+        if (!gruntOutputDir.exists() || gruntOutputDir.list()?.length == 0) {
+            return true
+        }
+
+        // Need npm install + grunt if node_modules is missing
         if (!nodeModulesDir.exists()) {
             return true
-        } else {
-            def srcDirModified = srcDir.exists() && srcDir.lastModified() > nodeModulesDir.lastModified()
-            def packageJsonModified = packageJson.exists() && packageJson.lastModified() > nodeModulesDir.lastModified()
-            def packageLockJsonModified = packageLockJson.exists() && packageLockJson.lastModified() > nodeModulesDir.lastModified()
-            def gruntFileModified = gruntFile.exists() && gruntFile.lastModified() > nodeModulesDir.lastModified()
-
-            def filesChanged = srcDirModified || packageJsonModified || packageLockJsonModified || gruntFileModified
-
-            return filesChanged
         }
+
+        // Check if sources are newer than grunt output
+        def srcDirModified = srcDir.exists() && srcDir.lastModified() > gruntOutputDir.lastModified()
+        def packageJsonModified = packageJson.exists() && packageJson.lastModified() > gruntOutputDir.lastModified()
+        def packageLockJsonModified = packageLockJson.exists() && packageLockJson.lastModified() > gruntOutputDir.lastModified()
+        def gruntFileModified = gruntFile.exists() && gruntFile.lastModified() > gruntOutputDir.lastModified()
+
+        return srcDirModified || packageJsonModified || packageLockJsonModified || gruntFileModified
     }
 }
 

--- a/nodel-webui-js/package-lock.json
+++ b/nodel-webui-js/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "bootskel",
       "version": "0.0.1",
       "license": "MPL-2.0",
       "dependencies": {
@@ -240,7 +241,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
       "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
       "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -265,13 +265,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.1.1"
+        "fill-range": "^7.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -647,11 +646,10 @@
       "dev": true
     },
     "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -927,7 +925,6 @@
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.1.tgz",
       "integrity": "sha512-ZXIYXTsAVrA7sM+jZxjQdrBOAg7DyMUplOMhTaspMRExei+fD0BTwdWXnn0W5SXqhb/Q/nlkzXclSi3IH55PIA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
@@ -1532,7 +1529,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1619,8 +1615,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-      "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes.",
-      "peer": true
+      "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes."
     },
     "node_modules/jquery.scrollbar": {
       "version": "0.2.11",
@@ -1628,11 +1623,10 @@
       "integrity": "sha1-6RvUqX2DhZRjAk0m5zDcNmdqtZ0="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2258,6 +2252,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
       "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+      "deprecated": "No longer maintained. Please upgrade to a stable version.",
       "dev": true,
       "dependencies": {
         "bytes": "1",
@@ -2553,7 +2548,6 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/nodel-webui-js/package-lock.json
+++ b/nodel-webui-js/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "bootskel",
       "version": "0.0.1",
       "license": "MPL-2.0",
       "dependencies": {
@@ -241,6 +240,7 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
       "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
       "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -265,12 +265,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -646,10 +647,11 @@
       "dev": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -925,6 +927,7 @@
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.1.tgz",
       "integrity": "sha512-ZXIYXTsAVrA7sM+jZxjQdrBOAg7DyMUplOMhTaspMRExei+fD0BTwdWXnn0W5SXqhb/Q/nlkzXclSi3IH55PIA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
@@ -1529,6 +1532,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1615,7 +1619,8 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-      "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes."
+      "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes.",
+      "peer": true
     },
     "node_modules/jquery.scrollbar": {
       "version": "0.2.11",
@@ -1623,10 +1628,11 @@
       "integrity": "sha1-6RvUqX2DhZRjAk0m5zDcNmdqtZ0="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2252,7 +2258,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
       "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-      "deprecated": "No longer maintained. Please upgrade to a stable version.",
       "dev": true,
       "dependencies": {
         "bytes": "1",
@@ -2548,6 +2553,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },


### PR DESCRIPTION
## Summary
- Adds Dockerfile with multi-stage build (builder → alpine runtime)
- Adds docker-compose.yml for local development
- Adds entrypoint.sh with stdin management for graceful shutdown
- Adds install.sh with PORT/NAME/IMAGE env var overrides
- Adds GitHub Actions workflow for automated image publishing (tags + manual dispatch)
- Adds DOCKER.md documentation

## Design decisions
- Runs as root for simpler volume permission handling
- Uses tini for proper signal forwarding
- Uses `tail -f /dev/null |` to keep stdin open (Nodel exits on EOF)
- Multi-arch support: amd64 + arm64

## Workflow
This is a staging PR to collect and track Docker support work. Commits from `wip/docker-support` will be squashed into `feature/docker-support` before creating a PR to `museumsvictoria/nodel`.

## Test plan
- [x] Build Docker image locally (`docker compose up --build`)
- [x] Run container with volume mounts
- [x] Verify web UI accessible at http://localhost:8085
- [x] Test install.sh with custom PORT/NAME
- [x] Verify HEALTHCHECK passes after startup