### PR TITLE
fix: duplication dialog refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _lastError.txt
 /nodel-webui-js/bin
 /nodel-jyhost/.nodel
 /nodel-jyhost/recipes
+/nodel-jyhost/*temp*/
 nodel-webui-js/node_modules/
 /nodel-webui-js/temp
 nodel-webui-js/src/dark/theme.less

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -112,3 +112,35 @@ rm -fr ~/nodel-build
 
 ---
 ¹ For macOS, adjust to suit.
+
+## TESTING (Integration & E2E)
+
+Nodel includes Playwright-based integration and E2E tests that run a dedicated nodehost on port `18085` in a temporary `nodelhost-temp/` directory.
+
+### Run tests
+```bash
+./gradlew :nodel-jyhost:integrationTest
+./gradlew :nodel-jyhost:e2eTest
+```
+
+### Visual debugging
+```bash
+HEADED=1 SLOWMO=500 ./gradlew :nodel-jyhost:e2eTest
+```
+
+### When tests fail
+1. Check `nodelhost-temp/output.log` and `nodelhost-temp/error.log` for server issues.
+2. Re-run with `HEADED=1` and/or `PWDEBUG=1` to watch or debug the browser.
+3. Check `nodel-jyhost/build/reports/tests/` for JUnit HTML reports.
+
+### Skip tests
+```bash
+./gradlew build -x test
+./gradlew build -x integrationTest -x e2eTest
+```
+
+### Discovery mode (tests)
+By default, tests use LocalAutoDNS for deterministic discovery results. To exercise real multicast discovery, set:
+```bash
+NODEL_TEST_DISCOVERY=1 ./gradlew :nodel-jyhost:integrationTest --tests org.nodel.DiscoverySmokeTests
+```

--- a/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
+++ b/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
@@ -1,0 +1,97 @@
+package org.nodel.discovery;
+
+/* 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ */
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.nodel.SimpleName;
+import org.nodel.core.NodeAddress;
+import org.nodel.core.Nodel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A local, non-multicast discovery implementation intended for deterministic testing.
+ * Uses in-process registrations and the current HTTP addresses from {@link Nodel}.
+ */
+public class LocalAutoDNS extends AutoDNS {
+
+    private final Logger _logger = LoggerFactory.getLogger(LocalAutoDNS.class);
+    private final ConcurrentMap<SimpleName, AdvertisementInfo> _advertisements = new ConcurrentHashMap<>();
+
+    private LocalAutoDNS() {
+        _logger.info("LocalAutoDNS enabled (test/local discovery).");
+    }
+
+    @Override
+    public NodeAddress resolveNodeAddress(SimpleName node) {
+        int tcpPort = Nodel.getTCPPort();
+        if (tcpPort <= 0) {
+            return null;
+        }
+        return NodeAddress.create("127.0.0.1", tcpPort);
+    }
+
+    @Override
+    public void registerService(SimpleName node) {
+        List<String> addresses = buildHttpAddresses();
+        long now = System.nanoTime() / 1000000L;
+        AdvertisementInfo info = _advertisements.computeIfAbsent(node, key -> new AdvertisementInfo(node, addresses, now));
+        info.refresh(node, addresses, now);
+    }
+
+    @Override
+    public Collection<AdvertisementInfo> list() {
+        return new ArrayList<>(_advertisements.values());
+    }
+
+    @Override
+    public AdvertisementInfo resolve(SimpleName node) {
+        return _advertisements.get(node);
+    }
+
+    @Override
+    public void unregisterService(SimpleName node) {
+        if (_advertisements.remove(node) == null) {
+            throw new IllegalStateException(node + " is not advertised anyway.");
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        _advertisements.clear();
+    }
+
+    private List<String> buildHttpAddresses() {
+        String[] httpAddresses = Nodel.getHTTPAddresses();
+        if (httpAddresses != null && httpAddresses.length > 0) {
+            return Arrays.asList(httpAddresses);
+        }
+        String fallback = String.format("http://127.0.0.1:%s%s", Nodel.getHTTPPort(), Nodel.getHTTPSuffix());
+        List<String> addresses = new ArrayList<>(1);
+        addresses.add(fallback);
+        return addresses;
+    }
+
+    public static AutoDNS create() {
+        return Instance.INSTANCE;
+    }
+
+    private static class Instance {
+        private static final LocalAutoDNS INSTANCE = new LocalAutoDNS();
+    }
+
+    public static LocalAutoDNS instance() {
+        return Instance.INSTANCE;
+    }
+}

--- a/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
+++ b/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
@@ -33,10 +33,19 @@ public class LocalAutoDNS extends AutoDNS {
         _logger.info("LocalAutoDNS enabled (test/local discovery).");
     }
 
+    /**
+     * Resolves any node to the local TCP address.
+     * Unlike the multicast implementation, this always returns localhost
+     * since LocalAutoDNS only tracks nodes within the same process.
+     *
+     * @param node the node name (ignored - all nodes resolve to localhost)
+     * @return NodeAddress pointing to 127.0.0.1 with the current TCP port, or null if TCP is not configured
+     */
     @Override
     public NodeAddress resolveNodeAddress(SimpleName node) {
         int tcpPort = Nodel.getTCPPort();
         if (tcpPort <= 0) {
+            _logger.warn("Cannot resolve node address for '{}': TCP port is not configured (port={})", node, tcpPort);
             return null;
         }
         return NodeAddress.create("127.0.0.1", tcpPort);
@@ -46,8 +55,13 @@ public class LocalAutoDNS extends AutoDNS {
     public void registerService(SimpleName node) {
         List<String> addresses = buildHttpAddresses();
         long now = System.nanoTime() / 1000000L;
-        AdvertisementInfo info = _advertisements.computeIfAbsent(node, key -> new AdvertisementInfo(node, addresses, now));
-        info.refresh(node, addresses, now);
+        _advertisements.compute(node, (key, existing) -> {
+            if (existing == null) {
+                return new AdvertisementInfo(node, addresses, now);
+            }
+            existing.refresh(node, addresses, now);
+            return existing;
+        });
     }
 
     @Override
@@ -63,7 +77,7 @@ public class LocalAutoDNS extends AutoDNS {
     @Override
     public void unregisterService(SimpleName node) {
         if (_advertisements.remove(node) == null) {
-            throw new IllegalStateException(node + " is not advertised anyway.");
+            _logger.warn("Attempted to unregister '{}' but it was not advertised", node);
         }
     }
 
@@ -78,11 +92,18 @@ public class LocalAutoDNS extends AutoDNS {
             return Arrays.asList(httpAddresses);
         }
         String fallback = String.format("http://127.0.0.1:%s%s", Nodel.getHTTPPort(), Nodel.getHTTPSuffix());
+        _logger.debug("HTTP addresses not configured; using fallback: {}", fallback);
         List<String> addresses = new ArrayList<>(1);
         addresses.add(fallback);
         return addresses;
     }
 
+    /**
+     * Creates (or returns the existing) LocalAutoDNS instance as an AutoDNS.
+     * Use this when only the AutoDNS interface is needed.
+     *
+     * @return the singleton LocalAutoDNS instance as an AutoDNS
+     */
     public static AutoDNS create() {
         return Instance.INSTANCE;
     }
@@ -91,6 +112,12 @@ public class LocalAutoDNS extends AutoDNS {
         private static final LocalAutoDNS INSTANCE = new LocalAutoDNS();
     }
 
+    /**
+     * Returns the singleton instance with the concrete LocalAutoDNS type.
+     * Use {@link #create()} when only the AutoDNS interface is needed.
+     *
+     * @return the singleton LocalAutoDNS instance
+     */
     public static LocalAutoDNS instance() {
         return Instance.INSTANCE;
     }

--- a/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
+++ b/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
@@ -93,9 +93,7 @@ public class LocalAutoDNS extends AutoDNS {
         }
         String fallback = String.format("http://127.0.0.1:%s%s", Nodel.getHTTPPort(), Nodel.getHTTPSuffix());
         _logger.debug("HTTP addresses not configured; using fallback: {}", fallback);
-        List<String> addresses = new ArrayList<>(1);
-        addresses.add(fallback);
-        return addresses;
+        return Arrays.asList(fallback);
     }
 
     /**

--- a/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
+++ b/nodel-framework/src/main/java/org/nodel/discovery/LocalAutoDNS.java
@@ -34,15 +34,19 @@ public class LocalAutoDNS extends AutoDNS {
     }
 
     /**
-     * Resolves any node to the local TCP address.
+     * Resolves an advertised node to the local TCP address.
      * Unlike the multicast implementation, this always returns localhost
      * since LocalAutoDNS only tracks nodes within the same process.
      *
-     * @param node the node name (ignored - all nodes resolve to localhost)
-     * @return NodeAddress pointing to 127.0.0.1 with the current TCP port, or null if TCP is not configured
+     * @param node the node name
+     * @return NodeAddress pointing to 127.0.0.1 with the current TCP port, or null if not advertised or TCP is not configured
      */
     @Override
     public NodeAddress resolveNodeAddress(SimpleName node) {
+        if (_advertisements.get(node) == null) {
+            _logger.debug("Cannot resolve node address for '{}': node is not advertised", node);
+            return null;
+        }
         int tcpPort = Nodel.getTCPPort();
         if (tcpPort <= 0) {
             _logger.warn("Cannot resolve node address for '{}': TCP port is not configured (port={})", node, tcpPort);
@@ -88,12 +92,34 @@ public class LocalAutoDNS extends AutoDNS {
 
     private List<String> buildHttpAddresses() {
         String[] httpAddresses = Nodel.getHTTPAddresses();
-        if (httpAddresses != null && httpAddresses.length > 0) {
+        if (httpAddresses != null && httpAddresses.length > 0 && !isDefaultHttpAddresses(httpAddresses)) {
             return Arrays.asList(httpAddresses);
         }
-        String fallback = String.format("http://127.0.0.1:%s%s", Nodel.getHTTPPort(), Nodel.getHTTPSuffix());
+        int httpPort = Nodel.getHTTPPort();
+        if (httpPort > 0) {
+            String fallback = String.format("http://127.0.0.1:%s%s", httpPort, Nodel.getHTTPSuffix());
+            _logger.debug("HTTP addresses not configured; using fallback: {}", fallback);
+            return Arrays.asList(fallback);
+        }
+        if (httpAddresses != null && httpAddresses.length > 0) {
+            _logger.debug("HTTP addresses not configured and HTTP port is unset; using existing addresses");
+            return Arrays.asList(httpAddresses);
+        }
+        String fallback = String.format("http://127.0.0.1%s", Nodel.getHTTPSuffix());
         _logger.debug("HTTP addresses not configured; using fallback: {}", fallback);
         return Arrays.asList(fallback);
+    }
+
+    private static boolean isDefaultHttpAddresses(String[] httpAddresses) {
+        if (httpAddresses.length != 1) {
+            return false;
+        }
+        String address = httpAddresses[0];
+        if (address == null) {
+            return true;
+        }
+        String trimmed = address.trim();
+        return "http://127.0.0.1".equals(trimmed) || "http://127.0.0.1/".equals(trimmed);
     }
 
     /**

--- a/nodel-jyhost/build.gradle
+++ b/nodel-jyhost/build.gradle
@@ -136,6 +136,9 @@ dependencies {
  */
 def nodelProcess = null
 def isWindows = System.getProperty('os.name').toLowerCase().contains('windows')
+def discoveryEnv = System.getenv('NODEL_TEST_DISCOVERY')
+def useLocalDiscovery = (discoveryEnv == null || discoveryEnv.trim().isEmpty()
+        || discoveryEnv.trim().equalsIgnoreCase('false') || discoveryEnv.trim().equals('0'))
 
 tasks.register('cleanNodelhostTemp', Delete) {
     delete layout.projectDirectory.dir('nodelhost-temp')
@@ -158,20 +161,28 @@ tasks.register('startNodelhost') {
         def tempDir = layout.projectDirectory.dir('nodelhost-temp').asFile
         tempDir.mkdirs()
 
+        if (useLocalDiscovery) {
+            logger.lifecycle("Using LocalAutoDNS for tests (set NODEL_TEST_DISCOVERY=1 for multicast discovery)")
+        } else {
+            logger.lifecycle("Using multicast AutoDNS for tests (NODEL_TEST_DISCOVERY enabled)")
+        }
+
         def pb
         if (isWindows) {
             // Windows: Start java directly with stdin pipe to keep process alive
-            pb = new ProcessBuilder(
-                'java', '-cp', sourceSets.main.runtimeClasspath.asPath,
-                '-ea', '-Dorg.nodel.discovery.impl=org.nodel.discovery.LocalAutoDNS;instance',
-                'org.nodel.jyhost.Launch', '-p', '18085'
-            )
+            def args = ['java', '-cp', sourceSets.main.runtimeClasspath.asPath, '-ea']
+            if (useLocalDiscovery) {
+                args.add('-Dorg.nodel.discovery.impl=org.nodel.discovery.LocalAutoDNS;instance')
+            }
+            args.addAll(['org.nodel.jyhost.Launch', '-p', '18085'])
+            pb = new ProcessBuilder(args)
             pb.redirectInput(ProcessBuilder.Redirect.PIPE)
         } else {
             // Unix: Use tail -f /dev/null to keep stdin open (prevents auto-shutdown)
+            def discoveryArg = useLocalDiscovery ? "-Dorg.nodel.discovery.impl='org.nodel.discovery.LocalAutoDNS;instance' " : ""
             pb = new ProcessBuilder(
                 'bash', '-c',
-                "tail -f /dev/null | java -cp '${sourceSets.main.runtimeClasspath.asPath}' -ea -Dorg.nodel.discovery.impl='org.nodel.discovery.LocalAutoDNS;instance' org.nodel.jyhost.Launch -p 18085"
+                "tail -f /dev/null | java -cp '${sourceSets.main.runtimeClasspath.asPath}' -ea ${discoveryArg}org.nodel.jyhost.Launch -p 18085"
             )
         }
         pb.directory(tempDir)

--- a/nodel-jyhost/build.gradle
+++ b/nodel-jyhost/build.gradle
@@ -163,14 +163,15 @@ tasks.register('startNodelhost') {
             // Windows: Start java directly with stdin pipe to keep process alive
             pb = new ProcessBuilder(
                 'java', '-cp', sourceSets.main.runtimeClasspath.asPath,
-                '-ea', 'org.nodel.jyhost.Launch', '-p', '18085'
+                '-ea', '-Dorg.nodel.discovery.impl=org.nodel.discovery.LocalAutoDNS;instance',
+                'org.nodel.jyhost.Launch', '-p', '18085'
             )
             pb.redirectInput(ProcessBuilder.Redirect.PIPE)
         } else {
             // Unix: Use tail -f /dev/null to keep stdin open (prevents auto-shutdown)
             pb = new ProcessBuilder(
                 'bash', '-c',
-                "tail -f /dev/null | java -cp '${sourceSets.main.runtimeClasspath.asPath}' -ea org.nodel.jyhost.Launch -p 18085"
+                "tail -f /dev/null | java -cp '${sourceSets.main.runtimeClasspath.asPath}' -ea -Dorg.nodel.discovery.impl='org.nodel.discovery.LocalAutoDNS;instance' org.nodel.jyhost.Launch -p 18085"
             )
         }
         pb.directory(tempDir)

--- a/nodel-jyhost/build.gradle
+++ b/nodel-jyhost/build.gradle
@@ -104,41 +104,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
 }
 
-/*
- * =============================================================================
- * E2E / INTEGRATION TEST INFRASTRUCTURE
- * =============================================================================
- *
- * Tests run a dedicated Nodel instance on port 18085 (not the default 8085)
- * in a temporary 'nodelhost-temp' directory for isolation.
- *
- * RUNNING TESTS:
- *   ./gradlew :nodel-jyhost:integrationTest    # API and smoke tests
- *   ./gradlew :nodel-jyhost:e2eTest            # Browser-based UI tests
- *
- * VISUAL DEBUGGING (see browser during E2E tests):
- *   Unix:
- *     HEADED=1 SLOWMO=500 ./gradlew :nodel-jyhost:e2eTest --rerun
- *   PowerShell:
- *     $env:HEADED=1; $env:SLOWMO=500; ./gradlew :nodel-jyhost:e2eTest --rerun
- *
- * WHEN TESTS FAIL:
- *   1. Check nodelhost-temp/output.log and error.log for server issues
- *   2. Re-run with HEADED=1 and/or PWDEBUG=1 to watch/interact with the browser
- *   3. Check build/reports/tests/ for JUnit HTML reports
- *   4. CI uploads failure artifacts (logs + reports) automatically
- *
- * SKIPPING TESTS:
- *   ./gradlew build -x test                    # Skip all tests
- *   ./gradlew build -x integrationTest -x e2eTest  # Skip only Playwright tests
- *
- * DISCOVERY MODE (tests):
- *   By default, tests use LocalAutoDNS for deterministic discovery results.
- *   To exercise real multicast discovery, set:
- *     NODEL_TEST_DISCOVERY=1 ./gradlew :nodel-jyhost:integrationTest --tests org.nodel.DiscoverySmokeTests
- *
- * =============================================================================
- */
+// Test infrastructure documentation moved to BUILDING.md (see "TESTING").
 def nodelProcess = null
 def isWindows = System.getProperty('os.name').toLowerCase().contains('windows')
 def discoveryEnv = System.getenv('NODEL_TEST_DISCOVERY')

--- a/nodel-jyhost/build.gradle
+++ b/nodel-jyhost/build.gradle
@@ -132,6 +132,11 @@ dependencies {
  *   ./gradlew build -x test                    # Skip all tests
  *   ./gradlew build -x integrationTest -x e2eTest  # Skip only Playwright tests
  *
+ * DISCOVERY MODE (tests):
+ *   By default, tests use LocalAutoDNS for deterministic discovery results.
+ *   To exercise real multicast discovery, set:
+ *     NODEL_TEST_DISCOVERY=1 ./gradlew :nodel-jyhost:integrationTest --tests org.nodel.DiscoverySmokeTests
+ *
  * =============================================================================
  */
 def nodelProcess = null

--- a/nodel-jyhost/src/test/java/org/nodel/DiscoverySmokeTests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/DiscoverySmokeTests.java
@@ -1,0 +1,59 @@
+package org.nodel;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Opt-in smoke test for real multicast discovery.
+ * Enable with: NODEL_TEST_DISCOVERY=1 ./gradlew :nodel-jyhost:integrationTest --tests org.nodel.DiscoverySmokeTests
+ */
+@Tag("discovery")
+public class DiscoverySmokeTests extends TestBase {
+
+    private static final String TEST_NODE = "Discovery Smoke Node";
+
+    @BeforeAll
+    public static void setup() {
+        initBrowser();
+        assumeTrue(isDiscoveryEnabled(), "NODEL_TEST_DISCOVERY not set; skipping multicast discovery smoke test");
+
+        boolean created = createTestNode(TEST_NODE, SIMPLE_TEST_SCRIPT);
+        assumeTrue(created, "Test node must be created for discovery smoke test");
+    }
+
+    @AfterAll
+    public static void teardown() {
+        deleteTestNode(TEST_NODE);
+        closeBrowser();
+    }
+
+    @Test
+    public void testNodeUrlsContainsLocalNode() {
+        assertTrue(waitForNodeUrlEntry(TEST_NODE, 30000),
+            "nodeURLs should include the local test node when multicast discovery is enabled");
+    }
+
+    private static boolean isDiscoveryEnabled() {
+        String value = System.getenv("NODEL_TEST_DISCOVERY");
+        if (value == null) return false;
+        String trimmed = value.trim();
+        return !trimmed.isEmpty() && !trimmed.equalsIgnoreCase("false") && !trimmed.equals("0");
+    }
+
+    private static boolean waitForNodeUrlEntry(String nodeName, int timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                String body = apiGet("/nodeURLs").text();
+                if (body.contains(nodeName)) {
+                    return true;
+                }
+                Thread.sleep(500);
+            } catch (Exception ignored) {
+            }
+        }
+        return false;
+    }
+}

--- a/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionE2ETests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionE2ETests.java
@@ -17,6 +17,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+/**
+ * End-to-end tests for the template selection UI in the add-node dialog.
+ * Tests recipe selection, node duplication with and without config copying,
+ * and card click behaviors.
+ */
 @Tag("e2e")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TemplateSelectionE2ETests extends TestBase {

--- a/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionE2ETests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionE2ETests.java
@@ -1,0 +1,377 @@
+package org.nodel;
+
+import com.microsoft.playwright.ElementHandle;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.WaitForSelectorState;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Tag("e2e")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TemplateSelectionE2ETests extends TestBase {
+
+    private static String runId;
+    private static String recipeName;
+    private static String recipeMarker;
+    private static String recipeScript;
+    private static String sourceNodeName;
+    private static String sourceScriptMarker;
+    private static String nodeConfigMarker;
+    private static Path tempDir;
+    private static Path nodesDir;
+    private static Path recipesDir;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        initBrowser();
+
+        tempDir = resolveTempDir();
+        nodesDir = tempDir.resolve("nodes");
+        recipesDir = tempDir.resolve("recipes");
+        Files.createDirectories(nodesDir);
+        Files.createDirectories(recipesDir);
+
+        runId = String.valueOf(System.currentTimeMillis());
+        recipeName = "E2ERecipe" + runId;
+        recipeMarker = "recipe-marker-" + runId;
+        recipeScript = "# " + recipeMarker + "\n" +
+            "def main():\n" +
+            "    console.info('Test node started')\n";
+        writeRecipe(recipeName, recipeScript);
+        assertTrue(waitForRecipeEntry(recipeName, 10000), "Recipe list must be available for template search");
+
+        sourceNodeName = "E2E Template Source " + runId;
+        sourceScriptMarker = "source-script-marker-" + runId;
+        String sourceScript = SIMPLE_TEST_SCRIPT + "\n# " + sourceScriptMarker + "\n";
+        assumeTrue(createTestNode(sourceNodeName, sourceScript), "Source node must be created");
+
+        nodeConfigMarker = "config-marker-" + runId;
+        String nodeConfigJson = "{\"remoteBindingValues\":{\"actions\":{\"testAction\":{\"node\":\"OtherNode\",\"action\":\"DoThing\"}},\"events\":{\"testEvent\":{\"node\":\"OtherNode\",\"event\":\"Triggered\"}}},\"paramValues\":{\"testParam\":\"" + nodeConfigMarker + "\"}}";
+        writeNodeConfig(sourceNodeName, nodeConfigJson);
+        writeSourceExtras(sourceNodeName);
+
+        assertTrue(waitForNodeUrlEntry(sourceNodeName, 30000), "Node URLs must be available for template search");
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        deleteTestNode(sourceNodeName);
+        deleteRecipe(recipeName);
+        closeBrowser();
+    }
+
+    @Test
+    @Order(1)
+    void testCreateNodeFromRecipeSelection() throws Exception {
+        openAddNodeDropdown();
+        typeTemplateSearch(recipeName);
+        waitForAutocompleteItemInSection("Recipes", recipeName);
+        selectAutocompleteItemInSection("Recipes", recipeName);
+
+        Locator card = page.locator(".template-selection-card").first();
+        assertTrue(card.locator(".card-type").innerText().contains("Recipe"));
+        assertNull(card.getAttribute("data-address"));
+        assertEquals(0, page.locator(".copy-config-option").count());
+
+        String newNodeName = "E2E Recipe Node " + runId;
+        page.locator(".nodel-add input.nodenamval").first().fill(newNodeName);
+        page.locator(".nodel-add .nodeaddsubmit").first().click();
+
+        assertTrue(waitForNodeInList(newNodeName, 15000), "Recipe-based node should appear in node list");
+        assertTrue(waitForFileContains(newNodeName, "script.py", recipeMarker, 10000),
+            "Recipe-based node should contain recipe script marker");
+
+        deleteTestNode(newNodeName);
+    }
+
+    @Test
+    @Order(2)
+    void testDuplicateNodeWithoutConfigCopy() throws Exception {
+        openAddNodeDropdown();
+        typeTemplateSearch(sourceNodeName);
+        waitForAutocompleteItemInSection("Existing Nodes", sourceNodeName);
+        selectAutocompleteItemInSection("Existing Nodes", sourceNodeName);
+
+        Locator card = page.locator(".template-selection-card").first();
+        assertNotNull(card.getAttribute("data-address"));
+
+        Locator includeConfig = page.locator(".copy-config-option input.include-node-config").first();
+        assertTrue(includeConfig.isVisible());
+        assertFalse(includeConfig.isChecked());
+
+        String newNodeName = "E2E Duplicate Off " + runId;
+        page.locator(".nodel-add input.nodenamval").first().fill(newNodeName);
+        page.locator(".nodel-add .nodeaddsubmit").first().click();
+
+        assertTrue(waitForNodeInList(newNodeName, 15000), "Duplicated node should appear in node list");
+        assertTrue(waitForFileContains(newNodeName, "script.py", sourceScriptMarker, 10000),
+            "Duplicated node should copy script content");
+
+        String nodeConfigBody = apiGet("/nodes/" + encode(newNodeName) + "/files/contents?path=" +
+            URLEncoder.encode("nodeConfig.json", StandardCharsets.UTF_8)).text();
+        assertFalse(nodeConfigBody.contains(nodeConfigMarker), "Node config marker should not be copied");
+
+        String filesBody = apiGet("/nodes/" + encode(newNodeName) + "/files").text();
+        assertFalse(filesBody.contains("_ignore.txt"), "Excluded underscore files should not be copied");
+        assertFalse(filesBody.contains("script_backup_"), "Backup scripts should not be copied");
+
+        deleteTestNode(newNodeName);
+    }
+
+    @Test
+    @Order(3)
+    void testDuplicateNodeWithConfigCopy() throws Exception {
+        openAddNodeDropdown();
+        typeTemplateSearch(sourceNodeName);
+        waitForAutocompleteItemInSection("Existing Nodes", sourceNodeName);
+        selectAutocompleteItemInSection("Existing Nodes", sourceNodeName);
+
+        Locator includeConfig = page.locator(".copy-config-option input.include-node-config").first();
+        assertTrue(includeConfig.isVisible());
+        includeConfig.check();
+
+        String newNodeName = "E2E Duplicate On " + runId;
+        page.locator(".nodel-add input.nodenamval").first().fill(newNodeName);
+        page.locator(".nodel-add .nodeaddsubmit").first().click();
+
+        assertTrue(waitForNodeInList(newNodeName, 15000), "Duplicated node should appear in node list");
+        assertTrue(waitForFileContains(newNodeName, "script.py", sourceScriptMarker, 10000),
+            "Duplicated node should copy script content");
+
+        String nodeConfigBody = apiGet("/nodes/" + encode(newNodeName) + "/files/contents?path=" +
+            URLEncoder.encode("nodeConfig.json", StandardCharsets.UTF_8)).text();
+        assertTrue(nodeConfigBody.contains(nodeConfigMarker), "Node config marker should be copied");
+
+        deleteTestNode(newNodeName);
+    }
+
+    @Test
+    @Order(4)
+    void testTemplateCardBodyClickBehavior() throws Exception {
+        openAddNodeDropdown();
+        typeTemplateSearch(sourceNodeName);
+        waitForAutocompleteItemInSection("Existing Nodes", sourceNodeName);
+        selectAutocompleteItemInSection("Existing Nodes", sourceNodeName);
+
+        Locator card = page.locator(".template-selection-card").first();
+        String address = card.getAttribute("data-address");
+        assertNotNull(address);
+
+        installWindowOpenSpy();
+        card.locator(".card-body").click();
+        assertEquals(address, getLastOpenedUrl(), "Node card body should open source node URL");
+
+        card.locator(".card-header").click();
+        page.waitForSelector(".template-selection-card",
+            new Page.WaitForSelectorOptions().setState(WaitForSelectorState.DETACHED));
+        assertTrue(page.locator(".unified-template-search").first().isVisible());
+
+        typeTemplateSearch(recipeName);
+        waitForAutocompleteItemInSection("Recipes", recipeName);
+        selectAutocompleteItemInSection("Recipes", recipeName);
+
+        Locator recipeCard = page.locator(".template-selection-card").first();
+        clearOpenedUrls();
+        recipeCard.locator(".card-body").click();
+        assertNull(getLastOpenedUrl(), "Recipe card body should not open new tab");
+    }
+
+    private static void openAddNodeDropdown() {
+        page.navigate(BASE_URL);
+        waitForElement(".navbar");
+        Locator dropdown = page.locator(".nodel-add .addgrp .dropdown-toggle").first();
+        assumeTrue(dropdown.isVisible(), "Add node dropdown must exist");
+        dropdown.click();
+        Locator nodeNameInput = page.locator(".nodel-add input.nodenamval").first();
+        assumeTrue(nodeNameInput.isVisible(), "Node name input must exist");
+    }
+
+    private static void typeTemplateSearch(String query) {
+        Locator templateInput = page.locator(".nodel-add .unified-template-search").first();
+        assumeTrue(templateInput.isVisible(), "Template search input must exist");
+        templateInput.click();
+        templateInput.fill("");
+        templateInput.type(query);
+        page.waitForSelector(".template-autocomplete");
+    }
+
+    private static void waitForAutocompleteItemInSection(String section, String text) {
+        page.waitForFunction("(args) => {\n" +
+            "  const items = Array.from(document.querySelectorAll('.template-autocomplete li'));\n" +
+            "  let current = null;\n" +
+            "  for (const li of items) {\n" +
+            "    if (li.classList.contains('section-header')) {\n" +
+            "      current = (li.textContent || '').trim();\n" +
+            "      continue;\n" +
+            "    }\n" +
+            "    if (current === args.section && (li.textContent || '').includes(args.text)) return true;\n" +
+            "  }\n" +
+            "  return false;\n" +
+            "}", java.util.Map.of("section", section, "text", text));
+    }
+
+    private static void selectAutocompleteItemInSection(String section, String... texts) {
+        ElementHandle item = findAutocompleteItemInSection(section, texts);
+        assertNotNull(item, "Autocomplete item must be found in section: " + section);
+        item.dispatchEvent("mousedown");
+        waitForElement(".template-selection-card");
+    }
+
+    private static ElementHandle findAutocompleteItemInSection(String section, String... texts) {
+        List<ElementHandle> items = page.querySelectorAll(".template-autocomplete li");
+        String currentSection = null;
+        for (ElementHandle item : items) {
+            String className = item.getAttribute("class");
+            if (className != null && className.contains("section-header")) {
+                currentSection = item.innerText().trim();
+                continue;
+            }
+            if (currentSection == null || !currentSection.equals(section)) {
+                continue;
+            }
+            String text = item.innerText();
+            boolean matches = true;
+            for (String needle : texts) {
+                if (needle != null && !needle.isEmpty() && !text.contains(needle)) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    private static boolean waitForNodeUrlEntry(String nodeName, int timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                String body = apiGet("/nodeURLs").text();
+                if (body.contains(nodeName)) {
+                    return true;
+                }
+                Thread.sleep(500);
+            } catch (Exception ignored) {
+            }
+        }
+        return false;
+    }
+
+    private static boolean waitForRecipeEntry(String recipePath, int timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                String body = apiGet("/recipes/list").text();
+                if (body.contains(recipePath)) {
+                    return true;
+                }
+                Thread.sleep(500);
+            } catch (Exception ignored) {
+            }
+        }
+        return false;
+    }
+
+    private static boolean waitForFileContains(String nodeName, String filePath, String expected, int timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        String encodedPath = URLEncoder.encode(filePath, StandardCharsets.UTF_8);
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                String body = apiGet("/nodes/" + encode(nodeName) + "/files/contents?path=" + encodedPath).text();
+                if (body.contains(expected)) {
+                    return true;
+                }
+                Thread.sleep(500);
+            } catch (Exception ignored) {
+            }
+        }
+        return false;
+    }
+
+    private static Path resolveTempDir() {
+        Path candidate = Paths.get("nodelhost-temp");
+        if (!Files.exists(candidate)) {
+            candidate = Paths.get("nodel-jyhost/nodelhost-temp");
+        }
+        if (!Files.exists(candidate)) {
+            throw new IllegalStateException("nodelhost-temp directory not found");
+        }
+        return candidate;
+    }
+
+    private static void writeRecipe(String name, String scriptContent) throws IOException {
+        Path recipeDir = recipesDir.resolve(name);
+        Files.createDirectories(recipeDir);
+        Files.writeString(recipeDir.resolve("script.py"), scriptContent);
+    }
+
+    private static void deleteRecipe(String name) throws IOException {
+        Path recipeDir = recipesDir.resolve(name);
+        if (Files.exists(recipeDir)) {
+            deleteDirectory(recipeDir);
+        }
+    }
+
+    private static void writeNodeConfig(String nodeName, String json) throws IOException {
+        Path nodeDir = nodesDir.resolve(nodeName);
+        Files.writeString(nodeDir.resolve("nodeConfig.json"), json);
+    }
+
+    private static void writeSourceExtras(String nodeName) throws IOException {
+        Path nodeDir = nodesDir.resolve(nodeName);
+        Files.writeString(nodeDir.resolve("_ignore.txt"), "ignore");
+        Files.writeString(nodeDir.resolve("script_backup_20240101.py"), "backup");
+    }
+
+    private static void deleteDirectory(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        Files.walk(dir)
+            .sorted((a, b) -> b.compareTo(a))
+            .forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                }
+            });
+    }
+
+    private static void installWindowOpenSpy() {
+        page.evaluate("() => {\n" +
+            "  window.__openedUrls = [];\n" +
+            "  const original = window.open;\n" +
+            "  window.__originalOpen = original;\n" +
+            "  window.open = function(url, target) {\n" +
+            "    window.__openedUrls.push({url: url, target: target});\n" +
+            "    return null;\n" +
+            "  };\n" +
+            "}");
+    }
+
+    private static void clearOpenedUrls() {
+        page.evaluate("() => { window.__openedUrls = []; }");
+    }
+
+    private static String getLastOpenedUrl() {
+        Object result = page.evaluate("() => {\n" +
+            "  const list = window.__openedUrls || [];\n" +
+            "  if (!list.length) return null;\n" +
+            "  return list[list.length - 1].url || null;\n" +
+            "}");
+        return result == null ? null : result.toString();
+    }
+}

--- a/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionIntegrationTests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionIntegrationTests.java
@@ -1,0 +1,47 @@
+package org.nodel;
+
+import org.junit.jupiter.api.*;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TemplateSelectionIntegrationTests extends TestBase {
+
+    @BeforeAll
+    static void setup() {
+        initBrowser();
+        navigateToHome();
+    }
+
+    @AfterAll
+    static void teardown() {
+        closeBrowser();
+    }
+
+    @Test
+    @Order(1)
+    void testDuplicateNodePreflightFailureDoesNotCreateNode() {
+        assertJsDefined("duplicateNode");
+
+        String runId = String.valueOf(System.currentTimeMillis());
+        String sourceUrl = BASE_URL + "/nodes/NonExistentNode" + runId + "/";
+        String newNodeName = "E2E Duplicate Preflight " + runId;
+
+        Object result = page.evaluate("async (args) => {\n" +
+            "  return await new Promise((resolve) => {\n" +
+            "    duplicateNode(args.source, args.name, {}, function() {})\n" +
+            "      .then(function() { resolve('resolved'); })\n" +
+            "      .fail(function(err) { resolve('rejected:' + (err && err.message)); });\n" +
+            "  });\n" +
+            "}", Map.of("source", sourceUrl, "name", newNodeName));
+
+        String resultText = String.valueOf(result);
+        assertTrue(resultText.startsWith("rejected:"), "Duplicate should fail when source is unreachable");
+        assertTrue(resultText.contains("Source node is not reachable"));
+
+        String nodesBody = apiGet("/nodes").text();
+        assertFalse(nodesBody.contains(newNodeName), "Node should not be created on preflight failure");
+    }
+}

--- a/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionIntegrationTests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/TemplateSelectionIntegrationTests.java
@@ -6,6 +6,10 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Integration tests for the duplicateNode JavaScript function.
+ * Verifies that preflight checks prevent node creation when the source is unreachable.
+ */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TemplateSelectionIntegrationTests extends TestBase {
 

--- a/nodel-webui-js/src/nodel.js
+++ b/nodel-webui-js/src/nodel.js
@@ -586,7 +586,9 @@ var duplicateNode = function(sourceNodeUrl, newNodeName, options, progressCallba
 var node = host = nodename = nodedesc = ''; //= opts = '';
 var converter = new Markdown.Converter();
 var unicodematch = new XRegExp("[^\\p{L}\\p{N}]", "gi");
-var simplematch = new RegExp(/^(.+?)(?:\(| \(| ?--|\/\/|$)/i);
+// Extracts the base node name by stopping at: parentheses "(", double-dash "--", or double-slash "//"
+// Examples: "Node Name (v2)" -> "Node Name", "Device--Location" -> "Device", "Service//Type" -> "Service"
+var simplematch = /^(.+?)(?:\(| \(| ?--|\/\/|$)/i;
 var colours = {'primary':'','success':'','danger':'','warning':'','info':'','default':''};
 var throttle = {'logs': {}};
 var allowedtxt = ['py','xml','xsl','js','json','html','htm','css','java','groovy','sql','sh','cs','bat','ini','txt','md','cmd'];
@@ -2068,7 +2070,7 @@ var setEvents = function(){
   }
 
   // Helper function to render selection card (replaces search field when selection made)
-  function renderTemplateSelectionPill(input, selection) {
+  function renderTemplateSelectionCard(input, selection) {
     var $parent = input.parent();
 
     // Clear existing selection UI
@@ -2092,7 +2094,7 @@ var setEvents = function(){
       var secondaryInfo = selection.name.substring(baseName.length).trim();
       name = baseName;
       detail = (secondaryInfo ? escapeHtml(secondaryInfo) + '<br>' : '') +
-               '<span class="card-host">' + escapeHtml(selection.host) + '</span>';
+               (selection.host ? '<span class="card-host">' + escapeHtml(selection.host) + '</span>' : '');
       icon = 'fa-copy text-info';
       label = 'Duplicate from';
     }
@@ -2146,6 +2148,10 @@ var setEvents = function(){
   $('body').on('click', '.template-selection-card .card-header', function(e) {
     e.preventDefault();
     var input = $(this).closest('.template-selection-card').siblings().find('.unified-template-search');
+    if (input.length === 0) {
+      console.warn('Template search input not found when clearing selection');
+      return;
+    }
     clearTemplateSelection(input, true);
     input.focus();
   });
@@ -2405,7 +2411,7 @@ var setEvents = function(){
 
     input.val(isRecipe ? selection.path : selection.name);
     input.data('templateSelection', selection);
-    renderTemplateSelectionPill(input, selection);
+    renderTemplateSelectionCard(input, selection);
     $autocomplete.remove();
   }
   $('body').on('mousedown touchstart', '.unified-template-search + .template-autocomplete ul li:not(.section-header)', handleTemplateSelection);

--- a/nodel-webui-js/src/nodel.js
+++ b/nodel-webui-js/src/nodel.js
@@ -500,7 +500,19 @@ var copyFilesSequentially = function(sourceUrl, destUrl, files) {
   return d.promise();
 };
 
-var duplicateNode = function(sourceNodeUrl, newNodeName, progressCallback) {
+// Filter function to exclude auto-generated and backup files during node duplication
+var shouldCopyFile = function(filePath) {
+  var fileName = filePath.split('/').pop();
+  // Exclude auto-generated files (start with underscore)
+  if (fileName.charAt(0) === '_') return false;
+  // Exclude script backup files
+  if (/^script_backup_.*\.py$/.test(fileName)) return false;
+  return true;
+};
+
+var duplicateNode = function(sourceNodeUrl, newNodeName, options, progressCallback) {
+  options = options || {};
+
   var d = $.Deferred();
 
   // Step 1: Verify source is reachable by getting file list
@@ -520,8 +532,21 @@ var duplicateNode = function(sourceNodeUrl, newNodeName, progressCallback) {
           return;
         }
 
-        // Step 4: Copy files sequentially
-        copyFilesSequentially(sourceNodeUrl, newNodeUrl, files)
+        // Step 4: Filter and copy files
+        var includeNodeConfig = options.includeNodeConfig;
+        var filesToCopy = files.filter(function(f) {
+          if (!shouldCopyFile(f.path)) return false;
+          if (!includeNodeConfig && f.path === 'nodeConfig.json') return false;
+          return true;
+        });
+        // Ensure script.py is copied last
+        var scriptFiles = [];
+        var otherFiles = [];
+        filesToCopy.forEach(function(f) {
+          (f.path === 'script.py' ? scriptFiles : otherFiles).push(f);
+        });
+        filesToCopy = otherFiles.concat(scriptFiles);
+        copyFilesSequentially(sourceNodeUrl, newNodeUrl, filesToCopy)
           .then(function(results) {
             if (results.failed.length > 0) {
               var failedDetails = results.failed.map(function(f) {
@@ -565,7 +590,7 @@ var duplicateNode = function(sourceNodeUrl, newNodeName, progressCallback) {
 var node = host = nodename = nodedesc = ''; //= opts = '';
 var converter = new Markdown.Converter();
 var unicodematch = new XRegExp("[^\\p{L}\\p{N}]", "gi");
-var simplematch = new RegExp(/^(.+?)(?:\(| \(|$)/i);
+var simplematch = new RegExp(/^(.+?)(?:\(| \(| ?--|\/\/|$)/i);
 var colours = {'primary':'','success':'','danger':'','warning':'','info':'','default':''};
 var throttle = {'logs': {}};
 var allowedtxt = ['py','xml','xsl','js','json','html','htm','css','java','groovy','sql','sh','cs','bat','ini','txt','md','cmd'];
@@ -2029,8 +2054,12 @@ var setEvents = function(){
   // Helper function to clear template selection state
   function clearTemplateSelection(input, clearValue) {
     input.removeData('templateSelection');
-    input.siblings('.template-selected').remove();
     input.siblings('.template-autocomplete').remove();
+    // Remove selection card and checkbox (siblings of input's parent div)
+    input.parent().siblings('.template-selection-card').remove();
+    input.parent().siblings('.copy-config-option').remove();
+    // Show the input wrapper again
+    input.parent().show();
     if (clearValue) input.val('');
   }
 
@@ -2042,13 +2071,59 @@ var setEvents = function(){
     return warnings.length > 0 ? 'Could not load ' + warnings.join(' or ') : null;
   }
 
-  // Helper function to render selection indicator
+  // Helper function to render selection card (replaces search field when selection made)
   function renderTemplateSelectionPill(input, selection) {
-    input.siblings('.template-selected').remove();
-    var tooltip = selection.type === 'recipe' ? 'Recipe: ' + selection.path : 'Node: ' + selection.name;
-    var indicator = $('<span class="template-selected"><i class="fa fa-check-circle"></i></span>');
-    indicator.attr('title', tooltip);
-    input.after(indicator);
+    var $parent = input.parent();
+
+    // Clear existing selection UI
+    $parent.siblings('.template-selection-card').remove();
+    $parent.siblings('.copy-config-option').remove();
+
+    // Hide the search input
+    $parent.hide();
+
+    var isRecipe = selection.type === 'recipe';
+    var name, detail, icon, label;
+
+    if (isRecipe) {
+      var parts = selection.path.split('/');
+      name = parts.pop();
+      detail = parts.join('/');
+      icon = 'fa-book text-success';
+      label = 'Recipe';
+    } else {
+      var baseName = getSimpleName(selection.name);
+      var secondaryInfo = selection.name.substring(baseName.length).trim();
+      name = baseName;
+      detail = (secondaryInfo ? escapeHtml(secondaryInfo) + '<br>' : '') +
+               '<span class="card-host">' + escapeHtml(selection.host) + '</span>';
+      icon = 'fa-copy text-info';
+      label = 'Duplicate from';
+    }
+
+    // For recipes, detail is plain text; for nodes, it's pre-built HTML
+    var detailHtml = isRecipe ? escapeHtml(detail) : detail;
+
+    var card = $('<div class="template-selection-card">' +
+      '<div class="card-header">' +
+        '<span class="card-type"><i class="fa ' + icon + '"></i> ' + label + '</span>' +
+        '<a href="#" class="card-change"><i class="fa fa-times"></i></a>' +
+      '</div>' +
+      '<div class="card-body">' +
+        '<div class="card-name">' + escapeHtml(name) + '</div>' +
+        (detail ? '<div class="card-detail text-muted">' + detailHtml + '</div>' : '') +
+      '</div>' +
+    '</div>');
+
+    $parent.after(card);
+
+    // Add config checkbox for node duplication only
+    if (!isRecipe) {
+      card.after($('<label class="copy-config-option">' +
+        '<input type="checkbox" class="include-node-config"> ' +
+        'Copy configuration <span class="text-muted">(parameters &amp; bindings)</span>' +
+      '</label>'));
+    }
   }
 
   $('body').on('shown.bs.dropdown', '.nodel-add .addgrp', function () {
@@ -2068,6 +2143,14 @@ var setEvents = function(){
     // Refresh recipes list when opening the add-node UI.
     // This keeps the cache reasonably fresh for users who add recipes while the nodehost is running.
     refreshRecipesList(true);
+  });
+
+  // Handle "Change" click on selection card - return to search mode
+  $('body').on('click', '.template-selection-card .card-change', function(e) {
+    e.preventDefault();
+    var input = $(this).closest('.template-selection-card').siblings().find('.unified-template-search');
+    clearTemplateSelection(input, true);
+    input.focus();
   });
   // Unified template search for add node modal
   var RECIPES_LIST_TTL_MS = 60 * 1000;
@@ -2126,7 +2209,8 @@ var setEvents = function(){
 
     // Clear selection state when typing (but not the autocomplete dropdown or value)
     $ele.removeData('templateSelection');
-    $ele.siblings('.template-selected').remove();
+    $ele.parent().siblings('.template-selection-card').remove();
+    $ele.parent().siblings('.copy-config-option').remove();
 
     clearTimeout(state.timeoutId);
     state.timeoutId = setTimeout(function() {
@@ -2300,28 +2384,22 @@ var setEvents = function(){
         break;
     }
   });
-  // Handle selection in unified template search
-  $('body').on('click', '.clear-template-selection', function(e) {
-    e.preventDefault();
-    var input = $(this).closest('.template-selected').siblings('.unified-template-search');
-    clearTemplateSelection(input, false);
-  });
-
   function handleTemplateSelection(e) {
     e.preventDefault();
     e.stopPropagation();
     var $li = $(this);
-    var input = $li.closest('.template-autocomplete').siblings('.unified-template-search');
-    var type = $li.data('type');
+    var $autocomplete = $li.closest('.template-autocomplete');
+    var input = $autocomplete.siblings('.unified-template-search');
+    var isRecipe = $li.data('type') === 'recipe';
 
-    var selection = type === 'recipe'
+    var selection = isRecipe
       ? {type: 'recipe', path: $li.data('path')}
       : {type: 'node', address: $li.data('address'), name: $li.data('name'), host: $li.data('host')};
 
-    input.val(type === 'recipe' ? selection.path : selection.name);
+    input.val(isRecipe ? selection.path : selection.name);
     input.data('templateSelection', selection);
     renderTemplateSelectionPill(input, selection);
-    $li.closest('.template-autocomplete').remove();
+    $autocomplete.remove();
   }
   $('body').on('mousedown touchstart', '.unified-template-search + .template-autocomplete ul li:not(.section-header)', handleTemplateSelection);
   $('body').on('keyup', '.nodenamval', function(e) {
@@ -2347,8 +2425,10 @@ var setEvents = function(){
 
     if (selection && selection.type === 'node') {
       // Duplicate from existing node
+      var includeConfig = $(ele).find('.include-node-config').is(':checked');
+      var duplicateOptions = { includeNodeConfig: includeConfig };
       var duplicateAlertShown = false;
-      duplicateNode(selection.address, nodenameraw, function() {
+      duplicateNode(selection.address, nodenameraw, duplicateOptions, function() {
         if (duplicateAlertShown) return;
         duplicateAlertShown = true;
         alert('Duplicating node...', 'info', 0);

--- a/nodel-webui-js/src/nodel.js
+++ b/nodel-webui-js/src/nodel.js
@@ -2122,7 +2122,7 @@ var setEvents = function(){
     if (!isRecipe) {
       card.after($('<label class="copy-config-option">' +
         '<input type="checkbox" class="include-node-config"> ' +
-        'Copy configuration <span class="text-muted">(parameters &amp; bindings)</span>' +
+        'Copy configuration&nbsp;<span class="text-muted">(parameters &amp; bindings)</span>' +
       '</label>'));
     }
   }

--- a/nodel-webui-js/src/nodel.js
+++ b/nodel-webui-js/src/nodel.js
@@ -532,20 +532,16 @@ var duplicateNode = function(sourceNodeUrl, newNodeName, options, progressCallba
           return;
         }
 
-        // Step 4: Filter and copy files
+        // Step 4: Filter and copy files (script.py last to trigger node restart after all files are in place)
         var includeNodeConfig = options.includeNodeConfig;
         var filesToCopy = files.filter(function(f) {
-          if (!shouldCopyFile(f.path)) return false;
-          if (!includeNodeConfig && f.path === 'nodeConfig.json') return false;
-          return true;
+          return shouldCopyFile(f.path) && (includeNodeConfig || f.path !== 'nodeConfig.json');
+        }).sort(function(a, b) {
+          // script.py should be copied last
+          if (a.path === 'script.py') return 1;
+          if (b.path === 'script.py') return -1;
+          return 0;
         });
-        // Ensure script.py is copied last
-        var scriptFiles = [];
-        var otherFiles = [];
-        filesToCopy.forEach(function(f) {
-          (f.path === 'script.py' ? scriptFiles : otherFiles).push(f);
-        });
-        filesToCopy = otherFiles.concat(scriptFiles);
         copyFilesSequentially(sourceNodeUrl, newNodeUrl, filesToCopy)
           .then(function(results) {
             if (results.failed.length > 0) {
@@ -2162,6 +2158,7 @@ var setEvents = function(){
       window.open(address, '_blank');
     }
   });
+
   // Unified template search for add node modal
   var RECIPES_LIST_TTL_MS = 60 * 1000;
   var recipesListCache = {data: null, fetchedAtMs: 0, xhr: null};

--- a/nodel-webui-js/src/nodel.js
+++ b/nodel-webui-js/src/nodel.js
@@ -2104,7 +2104,8 @@ var setEvents = function(){
     // For recipes, detail is plain text; for nodes, it's pre-built HTML
     var detailHtml = isRecipe ? escapeHtml(detail) : detail;
 
-    var card = $('<div class="template-selection-card">' +
+    var card = $('<div class="template-selection-card"' +
+      (!isRecipe ? ' data-address="' + escapeHtml(selection.address) + '"' : '') + '>' +
       '<div class="card-header">' +
         '<span class="card-type"><i class="fa ' + icon + '"></i> ' + label + '</span>' +
         '<a href="#" class="card-change"><i class="fa fa-times"></i></a>' +
@@ -2151,6 +2152,15 @@ var setEvents = function(){
     var input = $(this).closest('.template-selection-card').siblings().find('.unified-template-search');
     clearTemplateSelection(input, true);
     input.focus();
+  });
+
+  // Handle body click on node selection card - open source node in new tab
+  $('body').on('click', '.template-selection-card .card-body', function(e) {
+    var address = $(this).closest('.template-selection-card').data('address');
+    if (address) {
+      e.preventDefault();
+      window.open(address, '_blank');
+    }
   });
   // Unified template search for add node modal
   var RECIPES_LIST_TTL_MS = 60 * 1000;

--- a/nodel-webui-js/src/nodel.js
+++ b/nodel-webui-js/src/nodel.js
@@ -2145,8 +2145,8 @@ var setEvents = function(){
     refreshRecipesList(true);
   });
 
-  // Handle "Change" click on selection card - return to search mode
-  $('body').on('click', '.template-selection-card .card-change', function(e) {
+  // Handle header click on selection card - return to search mode
+  $('body').on('click', '.template-selection-card .card-header', function(e) {
     e.preventDefault();
     var input = $(this).closest('.template-selection-card').siblings().find('.unified-template-search');
     clearTemplateSelection(input, true);

--- a/nodel-webui-js/src/theme.less
+++ b/nodel-webui-js/src/theme.less
@@ -837,14 +837,17 @@ div.nodel-charts {
 }
 
 .copy-config-option {
-  display: block;
+  display: flex;
+  align-items: center;
   font-weight: normal;
   margin-top: @padding-base-vertical;
+  margin-left: 2px;
   font-size: @font-size-small;
   cursor: pointer;
+  user-select: none;
 
   input[type="checkbox"] {
-    margin-right: 4px;
+    margin: 0 6px 0 0;
   }
 }
 .nodel-toolkit {

--- a/nodel-webui-js/src/theme.less
+++ b/nodel-webui-js/src/theme.less
@@ -779,7 +779,19 @@ div.nodel-charts {
     align-items: center;
     padding: (@padding-base-vertical * 0.75) @padding-base-horizontal;
     border-bottom: 1px solid @panel-default-border;
+    border-radius: @panel-border-radius @panel-border-radius 0 0;
     font-size: @font-size-small;
+    cursor: pointer;
+    transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+    &:hover {
+      box-shadow: inset 0 0 0 1px fade(@brand-danger, 50%);
+
+      .card-change {
+        color: @brand-danger;
+        opacity: 1;
+      }
+    }
   }
 
   .card-type {
@@ -789,10 +801,7 @@ div.nodel-charts {
   .card-change {
     color: @text-muted;
     opacity: 0.6;
-    &:hover {
-      color: @brand-danger;
-      opacity: 1;
-    }
+    transition: color 0.15s ease-in-out, opacity 0.15s ease-in-out;
   }
 
   .card-body {

--- a/nodel-webui-js/src/theme.less
+++ b/nodel-webui-js/src/theme.less
@@ -806,6 +806,17 @@ div.nodel-charts {
 
   .card-body {
     padding: @padding-base-vertical @padding-base-horizontal;
+    border-radius: 0 0 @panel-border-radius @panel-border-radius;
+    transition: box-shadow 0.15s ease-in-out;
+  }
+
+  // Only nodes have data-address, so this targets node cards only
+  &[data-address] .card-body {
+    cursor: pointer;
+
+    &:hover {
+      box-shadow: inset 0 0 0 1px fade(@brand-info, 50%);
+    }
   }
 
   .card-name {

--- a/nodel-webui-js/src/theme.less
+++ b/nodel-webui-js/src/theme.less
@@ -767,16 +767,65 @@ div.nodel-charts {
     }
   }
 }
-.template-selected {
-  position: absolute;
-  right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: @brand-success;
-  font-size: @font-size-base;
-  pointer-events: none;
-  background: @input-bg;
-  padding-left: 4px;
+.template-selection-card {
+  background: @panel-bg;
+  border: 1px solid @panel-default-border;
+  border-radius: @panel-border-radius;
+  margin-top: @padding-xs-vertical;
+
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: (@padding-base-vertical * 0.75) @padding-base-horizontal;
+    border-bottom: 1px solid @panel-default-border;
+    font-size: @font-size-small;
+  }
+
+  .card-type {
+    color: @text-muted;
+  }
+
+  .card-change {
+    color: @text-muted;
+    opacity: 0.6;
+    &:hover {
+      color: @brand-danger;
+      opacity: 1;
+    }
+  }
+
+  .card-body {
+    padding: @padding-base-vertical @padding-base-horizontal;
+  }
+
+  .card-name {
+    font-weight: bold;
+    word-break: break-word;
+  }
+
+  .card-detail {
+    font-size: @font-size-small;
+    margin-top: 2px;
+
+    .card-host {
+      display: block;
+      margin-top: 4px;
+      font-family: @font-family-monospace;
+    }
+  }
+}
+
+.copy-config-option {
+  display: block;
+  font-weight: normal;
+  margin-top: @padding-base-vertical;
+  font-size: @font-size-small;
+  cursor: pointer;
+
+  input[type="checkbox"] {
+    margin-right: 4px;
+  }
 }
 .nodel-toolkit {
   margin-bottom: @form-group-margin-bottom;


### PR DESCRIPTION
Follow-up polish to #373.

[967125566fe7529e54c8f588fc2d8468.webm](https://github.com/user-attachments/assets/6c9d30c1-3870-40e1-a0eb-0820fd441001)

The duplication dialog now shows a proper selection card with the node's secondary info (descriptor, host) instead of just the name. Clicking the card body opens the source node in a new tab so you can inspect it before duplicating. Config copying is opt-in via checkbox, and auto-generated files (underscore-prefixed, script backups) are filtered out during copy.

Also adds E2E tests for template selection using a new `LocalAutoDNS` class that enables deterministic discovery without multicast - useful for CI environments where multicast isn't available.